### PR TITLE
Added properties for startup timeout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ subprojects {
     apply plugin: 'checkstyle'
 
     group = "org.testcontainers"
+    version = '1.17.6-j1'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=false
 org.gradle.caching=true
 org.gradle.configureondemand=true
-testcontainers.version=1.17.6
+testcontainers.version=1.17.6-j1

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
@@ -6,6 +6,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.JdbcDatabaseContainerProvider;
 import org.testcontainers.delegate.DatabaseDelegate;
 import org.testcontainers.ext.ScriptUtils;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -107,6 +108,12 @@ public class ContainerDatabaseDriver implements Driver {
                 for (JdbcDatabaseContainerProvider candidateContainerType : databaseContainers) {
                     if (candidateContainerType.supports(connectionUrl.getDatabaseType())) {
                         container = candidateContainerType.newInstance(connectionUrl);
+
+                        int startupTimeout = Integer.parseInt(TestcontainersConfiguration.getInstance().getEnvVarOrProperty("tc.jdbc.startuptimeout", "120"));
+                        int connectionTimeout = Integer.parseInt(TestcontainersConfiguration.getInstance().getEnvVarOrProperty("tc.jdbc.connectiontimeout", "120"));
+                        container.withStartupTimeoutSeconds(startupTimeout);
+                        container.withConnectTimeoutSeconds(connectionTimeout);
+
                         container.withTmpFs(connectionUrl.getTmpfsOptions());
                         delegate = container.getJdbcDriverInstance();
                     }

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
@@ -109,8 +109,16 @@ public class ContainerDatabaseDriver implements Driver {
                     if (candidateContainerType.supports(connectionUrl.getDatabaseType())) {
                         container = candidateContainerType.newInstance(connectionUrl);
 
-                        int startupTimeout = Integer.parseInt(TestcontainersConfiguration.getInstance().getEnvVarOrProperty("tc.jdbc.startuptimeout", "120"));
-                        int connectionTimeout = Integer.parseInt(TestcontainersConfiguration.getInstance().getEnvVarOrProperty("tc.jdbc.connectiontimeout", "120"));
+                        int startupTimeout = Integer.parseInt(
+                            TestcontainersConfiguration
+                                .getInstance()
+                                .getEnvVarOrProperty("tc.jdbc.startuptimeout", "120")
+                        );
+                        int connectionTimeout = Integer.parseInt(
+                            TestcontainersConfiguration
+                                .getInstance()
+                                .getEnvVarOrProperty("tc.jdbc.connectiontimeout", "120")
+                        );
                         container.withStartupTimeoutSeconds(startupTimeout);
                         container.withConnectTimeoutSeconds(connectionTimeout);
 


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Added new overridable properties to specify startup timeout of the containers startup. For my build I had to set these properties to 600. The properties are:
tc.jdbc.startuptimeout=120
tc.jdbc.connectiontimeout=120